### PR TITLE
fix issue when get schema from miscellaneous array

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -189,21 +189,24 @@
 			if (keyString === '' || (usePositiveFields && (!fields.hasOwnProperty(keyString) || fields[keyString] !== 1)) || (useNegativeFields && fields.hasOwnProperty(keyString) && fields[keyString] === -1)) {
 				return keyInfo;
 			}
+            // We need to emit this key
+            if (!keyInfo.hasOwnProperty(keyString)) {
+                keyInfo[keyString] = {};
+            }
+            
+            if (!keyInfo[keyString].hasOwnProperty(type)) {
+                keyInfo[keyString][type] = {
+                    docs : 1,
+                    coverage : 0,
+                    perDoc : 0,
+                };
+            }
 
-			// We need to emit this key
-			if (keyInfo.hasOwnProperty(keyString) && keyInfo[keyString].hasOwnProperty(type)) {
-				keyInfo[keyString][type].perDoc += 1;
-			} else {
-				keyInfo[keyString] = {};
-				keyInfo[keyString][type] = {
-					docs : 1,
-					coverage : 0,
-					perDoc : 1
-				};
-			}
+            keyInfo[keyString][type].perDoc += 1;
 
 			return keyInfo;
 		};
+
 
 		/**
 		 * @function


### PR DESCRIPTION
@skratchdot 
When get schema from miscellaneous array, such as:

```
{things : [1,"name"]}
```

Current schema script will return:

```
 {
           "_id" : "things.$",
           "value" : {
                "wildcard" : true,
                "types" : [
                     "string"
                ],
                "results" : [
                     {
                          "type" : "all",
                          "docs" : 1,
                          "coverage" : 100,
                          "perDoc" : 1
                     },
                     {
                          "type" : "string",
                          "docs" : 1,
                          "coverage" : 100,
                          "perDoc" : 1
                     }
                ]
           }
      }
```

There is no number in this schema, I fix it and current result like that:

```
      {
           "_id" : "things.$",
           "value" : {
                "wildcard" : true,
                "types" : [
                     "number",
                     "string"
                ],
                "results" : [
                     {
                          "type" : "all",
                          "docs" : 1,
                          "coverage" : 100,
                          "perDoc" : 2
                     },
                     {
                          "type" : "number",
                          "docs" : 1,
                          "coverage" : 100,
                          "perDoc" : 1
                     },
                     {
                          "type" : "string",
                          "docs" : 1,
                          "coverage" : 100,
                          "perDoc" : 1
                     }
                ]
           }
      }
```

Thank you very much :)
